### PR TITLE
Remover forma deprecada de crear el store

### DIFF
--- a/app/client/index.jsx
+++ b/app/client/index.jsx
@@ -12,9 +12,8 @@ window.regeneratorRuntime = _regeneratorRuntime;
 
 // Setup Redux & Get Initial App State
 const initialState = window.__initialAppState;
-const createStoreWithMiddleware = applyMiddleware(thunk)(createStore);
 const reducer = combineReducers(reducers);
-const store = createStoreWithMiddleware(reducer, initialState);
+const store = createStore(reducer, initialState, applyMiddleware(thunk));
 
 ReactDOM.render(
   <App store={store} />,

--- a/app/server/index.jsx
+++ b/app/server/index.jsx
@@ -12,9 +12,8 @@ import {setLatestRestrictionDay} from '../actions/RestrictionDayActions';
 import App from '../components/App.jsx';
 
 
-const createStoreWithMiddleware = applyMiddleware(thunk)(createStore);
 const reducer = combineReducers(reducers);
-const store = createStoreWithMiddleware(reducer);
+const store = createStore(reducer, applyMiddleware(thunk));
 
 
 export default function* (){


### PR DESCRIPTION
Usar la forma que propone Dan Abramov para definir el store.

Me di cuenta al ver un [tweet](https://twitter.com/dan_abramov/status/729359212912988160) de Dan Abramov y la solución la busqué en los [ejemplos](https://github.com/reactjs/redux/blob/master/examples/shopping-cart/index.js) del repo de redux. 

PD: agradecería testear porque yo no pude correr la app localmente